### PR TITLE
Refactored variable Arrow to eliminate the underline

### DIFF
--- a/src/components/Slider.jsx
+++ b/src/components/Slider.jsx
@@ -2,9 +2,9 @@ import { ArrowLeftOutlined, ArrowRightOutlined } from '@material-ui/icons';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
+import ButtonElement from '../components/Button';
 import { sliderItems } from '../data/sliderData';
 import { mobile } from '../responsive';
-import ButtonElement from '../components/Button';
 
 const Container = styled.section`
   width: 100%;
@@ -33,10 +33,6 @@ const Arrow = styled.div`
   cursor: pointer;
   opacity: 0.5;
   z-index: 2;
-  &:focus {
-    background-color: ${({ theme }) => theme.bgLighter};
-    border: 5px solid ${({ theme }) => theme.hover};
-    color: ${({ theme }) => theme.text};
   }
 `;
 


### PR DESCRIPTION
- [X] I've deleted the Focus property of the Arrow element that made the underline

Link Trello: https://trello.com/c/xE67B0Zs/48-boton-slider-eliminar-el-underline


Video Showing the Change: https://github.com/yamilt351/ecomerceDemo/assets/112005486/49909a0e-a6d5-402a-890f-25faaaa6e490

